### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@goanpeca](https://github.com/goanpeca/)
 * [@jaimergp](https://github.com/jaimergp/)
 * [@zoccoler](https://github.com/zoccoler/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - goanpeca
     - jaimergp
     - zoccoler


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #2